### PR TITLE
Result of SQL on benchmarking Postgres pod

### DIFF
--- a/data/history_runtimes.txt
+++ b/data/history_runtimes.txt
@@ -1,0 +1,26 @@
+ history_id |        create_time         |                              tool_id                               |     job_memory_gb      | cpu_count |  total_runtime_sec   
+------------+----------------------------+--------------------------------------------------------------------+------------------------+-----------+----------------------
+         20 | 2021-07-16 05:34:57.420143 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1          | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 04:28:40.465351 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4              | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 05:03:53.163886 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1          | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 07:03:02.224351 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1          |     8.0000000000000000 | 4.0000000 | 12140.00000000000000
+         20 | 2021-07-16 13:20:24.51696  | toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy7       | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 13:20:24.420054 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1          | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 13:20:24.315648 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4              | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 13:20:24.197373 | toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.4.2+galaxy0 | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 04:28:06.956484 | __DATA_FETCH__                                                     |     2.0000000000000000 | 1.0000000 |   191.00000000000000
+         20 | 2021-07-16 05:03:53.255484 | toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy7       |     4.0000000000000000 | 2.0000000 |  1164.00000000000000
+         20 | 2021-07-16 05:03:52.875029 | toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.4.2+galaxy0 |     4.0000000000000000 | 2.0000000 |  6974.00000000000000
+         20 | 2021-07-16 04:28:40.583836 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1          | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 04:28:15.541837 | toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.4.2+galaxy0 | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 04:28:15.728841 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4              | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 05:03:53.048919 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4              |     8.0000000000000000 | 4.0000000 | 26620.00000000000000
+         20 | 2021-07-16 04:28:15.821936 | toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1          | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 04:28:40.679963 | toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy7       | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 04:28:15.916962 | toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy7       | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-16 04:28:40.342846 | toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.4.2+galaxy0 | 0.00000000000000000000 |         1 |                    1
+         20 | 2021-07-20 23:52:39.851971 | toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0+galaxy7       |     8.0000000000000000 | 4.0000000 |  4476.00000000000000
+         20 | 2021-07-21 00:15:32.125309 | toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.4.2+galaxy0 |     8.0000000000000000 | 4.0000000 |  8116.00000000000000
+         20 | 2021-07-21 13:21:01.324047 | toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/2.1.1         |     2.0000000000000000 | 1.0000000 |   151.00000000000000
+(22 rows)
+


### PR DESCRIPTION
A table containing the results of running the `history_runtimes.sql` query on the Postrges pod in the benchmarking K8S cluster.